### PR TITLE
Pin NPM version to 1.4.0 for travis tests, 2.0.0-beta seems to be breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-before_install: npm update -g npm@1.4.3
+before_install: npm install -g npm@1.4.0
 node_js:
   - "0.8"
   - "0.10"


### PR DESCRIPTION
We use a `before_install` to update Node 0.8's NPM version to a version that supports the `^` version identifier, which is now standard. Travis seems to be updating NPM to 2.0.0-beta, which appears to be breaking during the tests. Pin the version to 1.4.0 as a fix.
