### PR TITLE
Added API functions that return promises

### DIFF
--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -9,6 +9,7 @@
 require("setimmediate"); // Shim to support setImmediate in Node 0.8.x
 
 var request = require('superagent');
+var Promise = require('bluebird');
 
 var Akismet = function(options) {
 
@@ -23,6 +24,9 @@ var Akismet = function(options) {
   this.version    = options.version || '1.1';
   this.endpoint   = options.endpoint || this.key + '.' + this.host + '/' + this.version + '/';
   this.userAgent  = options.userAgent || 'Node.js/' + process.version + ' | Akismet-api/1.1.0';
+
+  // saved to use context inside the Promises
+  var self = this;
 
   /*
    * Verify that the provided key is accepted by Akismet 
@@ -47,6 +51,44 @@ var Akismet = function(options) {
       else 
         cb(new Error(res.text), false);
     });
+
+
+  };
+
+  /*
+   * Verify that the provided key is accepted by Akismet
+   *
+   * Returns a promise that is resolved when the response is valid
+   * and throws an error otherwise.
+   */
+  this.verifyKeyAsync = function() {
+    return new Promise(function(resolve, reject){
+      var url = self.host + '/' + self.version + '/verify-key';
+      request
+          .post(url)
+          .type('form')
+          .send({
+            key  : self.key,
+            blog : self.blog
+          })
+          .set('User-Agent', self.userAgent)
+          .end(function(err, res) {
+            var error;
+
+            if (res && res.text == 'valid') resolve();
+
+            if (err) error = err;
+            else if (res.header['x-akismet-debug-help'])
+              error = res.header['x-akismet-debug-help'];
+            else if (res.text == 'invalid')
+              error = 'Invalid API key';
+            else
+              error = res.text;
+
+            reject(error);
+          });
+    });
+
   };
 
   /*
@@ -87,6 +129,50 @@ var Akismet = function(options) {
   };
 
   /*
+   * Check if the given data is spam
+   * Returns a promise that resolves to true for spam
+   * Returns a promise that resolves to false for ham
+   */
+  this.checkSpamAsync = function(options) {
+    return new Promise(function(resolve, reject){
+      var url = self.endpoint + 'comment-check';
+      options = options || {};
+      request
+          .post(url)
+          .type('form')
+          .send({
+            blog                 : self.blog,
+            user_ip              : options.user_ip || '',
+            permalink            : options.permalink || '',
+            user_agent           : options.user_agent || '',
+            comment_type         : options.comment_type || '',
+            comment_author       : options.comment_author || '',
+            comment_content      : options.comment_content || '',
+            comment_author_url   : options.comment_author_url || '',
+            comment_author_email : options.comment_author_email || '',
+            referrer             : options.referrer || options.referer || ''
+          })
+          .set('User-Agent', self.userAgent)
+          .end(function(err, res) {
+            var error;
+
+            if (res && res.text == 'true') resolve(true);
+            if (res && res.text == 'false') resolve(false);
+
+            if (err) error = err;
+            else if (res.header['x-akismet-debug-help'])
+              error = res.header['x-akismet-debug-help'];
+            else if (res.text == 'invalid')
+              error = 'Invalid API key';
+            else
+              error = res.text;
+
+            reject(error);
+          });
+    })
+  };
+
+  /*
    * Submit the given value as a false-negative
    * Essentially, tell Akismet that they told us this WASN'T spam, but it WAS 
    */
@@ -118,6 +204,44 @@ var Akismet = function(options) {
   };
 
   /*
+   * Submit the given value as a false-negative
+   * Essentially, tell Akismet that they told us this WASN'T spam, but it WAS
+   *
+   * Returns a promise that resolves when there is no error and throws an error otherwise.
+   */
+
+  this.submitSpamAsync = function(options) {
+    return new Promise(function(resolve, reject){
+      var url = self.endpoint + 'submit-spam';
+      options = options || {};
+      request
+          .post(url)
+          .type('form')
+          .send({
+            blog                 : this.blog,
+            user_ip              : options.user_ip || '',
+            permalink            : options.permalink || '',
+            user_agent           : options.user_agent || '',
+            comment_type         : options.comment_type || '',
+            comment_author       : options.comment_author || '',
+            comment_content      : options.comment_content || '',
+            comment_author_url   : options.comment_author_url || '',
+            comment_author_email : options.comment_author_email || '',
+            referrer             : options.referrer || options.referer || ''
+          })
+          .set('User-Agent', self.userAgent)
+          .end(function(err, res) {
+            var error;
+
+            if (res && res.statusType == 2) resolve();
+
+            error = err ? err : res.text;
+            reject(error);
+          });
+    });
+  };
+
+  /*
    * Submit the given value as a false-positive
    * Essentially, tell Akismet that they told us this WAS spam, but it WASN'T 
    */
@@ -144,6 +268,43 @@ var Akismet = function(options) {
       if (err) cb(err);
       else if (res.statusType == 2) cb(null);
       else cb(res.text);
+    });
+  };
+
+  /*
+   * Submit the given value as a false-positive
+   * Essentially, tell Akismet that they told us this WAS spam, but it WASN'T
+   *
+   * Returns a promise that resolves when there is no error and throws an error otherwise.
+   */
+  this.submitHamAsync = function(options) {
+    return new Promise(function(resolve, reject){
+      var url = self.endpoint + 'submit-ham';
+      options = options || {};
+      request
+          .post(url)
+          .type('form')
+          .send({
+            blog                 : self.blog,
+            user_ip              : options.user_ip || '',
+            permalink            : options.permalink || '',
+            user_agent           : options.user_agent || '',
+            comment_type         : options.comment_type || '',
+            comment_author       : options.comment_author || '',
+            comment_content      : options.comment_content || '',
+            comment_author_url   : options.comment_author_url || '',
+            comment_author_email : options.comment_author_email || '',
+            referrer             : options.referrer || options.referer || ''
+          })
+          .set('User-agent', self.userAgent)
+          .end(function(err, res) {
+            var error;
+
+            if (res && res.statusType == 2) resolve();
+
+            error = err ? err : res.text;
+            reject(error);
+          });
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "superagent": "^0.21.0"
   },
   "devDependencies": {
+    "bluebird": "^3.1.1",
     "chai": "^1.7.0",
-    "nock": "^0.41.0",
-    "mocha": "^1.11.0"
+    "mocha": "^1.11.0",
+    "nock": "^0.41.0"
   },
   "scripts": {
     "test": "node_modules/mocha/bin/mocha test/*.spec.js"

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -238,6 +238,148 @@ describe('Akismet-api', function() {
 
   });
 
+  describe('client#verifyKeyAsync()', function() {
+
+    describe('when the request returns \'valid\'', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey1',
+          host : 'rest1.akismet.com'
+        });
+        scope = nock('http://rest1.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/verify-key')
+            .reply(200, 'valid', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('promise should resolve', function(done) {
+        client.verifyKeyAsync().then(function() {
+          scope.done();
+          done();
+        });
+      });
+    });
+
+    describe('when the request returns \'invalid\'', function() {
+
+      describe('when the x-akismet-debug-help header is present', function() {
+
+        var client;
+        var scope;
+
+        beforeEach(function() {
+          client = Akismet.client({
+            blog : 'http://example.com',
+            key  : 'testKey2',
+            host : 'rest2.akismet.com'
+          });
+          scope = nock('http://rest2.akismet.com')
+              .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+              .post('/1.1/verify-key')
+              .reply(200, 'invalid', {
+                'Content-Type' : 'text/plain',
+                'X-akismet-debug-help' : 'Could not find your key'
+              });
+        });
+
+        it('should return the akismet debug error', function(done) {
+          client.verifyKeyAsync().catch(function(err){
+            expect(err).to.equal('Could not find your key');
+            scope.done();
+            done();
+          });
+        });
+
+      });
+
+      describe('when the x-akismet-debug-help header is not present', function() {
+
+        var client;
+        var scope;
+
+        beforeEach(function() {
+          client = Akismet.client({
+            blog : 'http://example.com',
+            key  : 'testKey2',
+            host : 'rest2.akismet.com'
+          });
+          scope = nock('http://rest2.akismet.com')
+              .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+              .post('/1.1/verify-key')
+              .reply(200, 'invalid', {
+                'Content-Type' : 'text/plain'
+              });
+        });
+
+        it('should return \'Invalid API key\'', function(done) {
+          client.verifyKeyAsync().catch(function(err){
+            expect(err).to.equal('Invalid API key');
+            scope.done();
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('when the request returns anything else', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey2',
+          host : 'rest2.akismet.com'
+        });
+        scope = nock('http://rest2.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/verify-key')
+            .reply(200, 'whatisthiserror', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should return the response', function(done) {
+        client.verifyKeyAsync().catch(function(err){
+          expect(err).to.equal('whatisthiserror');
+          scope.done();
+          done();
+        });
+      });
+    });
+
+    describe('when the request fails', function() {
+
+      var client;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey3',
+          host : 'localhost' // will fail!
+        });
+      });
+
+      it('should return the error', function(done) {
+        client.verifyKeyAsync().catch(function(err){
+          expect(err).to.not.be.null;
+          done();
+        });
+      });
+    });
+
+  });
+
   describe('client#checkSpam()', function() {
     
     describe('when the request returns \'true\'', function() {
@@ -439,26 +581,174 @@ describe('Akismet-api', function() {
 
   });
 
-  describe('client#submitSpam()', function() {
- 
-    describe('when the request returns a 2XX status code ', function() {
-    
+  describe('client#checkSpamAsync()', function() {
+
+    describe('when the request returns \'true\'', function() {
+
       var client;
       var scope;
-      
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey4'
+        });
+        scope = nock('http://testKey4.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/comment-check')
+            .reply(200, 'true', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should return true', function(done) {
+        client.checkSpamAsync({
+          user_ip : '123.123.123.123'
+        }).then(function(spam) {
+          expect(spam).to.be.true;
+          scope.done();
+          done();
+        });
+      });
+    });
+
+    describe('when the request returns \'false\'', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey5'
+        });
+        scope = nock('http://testKey5.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/comment-check')
+            .reply(200, 'false', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should return false', function(done) {
+        client.checkSpamAsync({
+          user_ip : '123.123.123.123'
+        }).then(function(spam) {
+          expect(spam).to.be.false;
+          scope.done();
+          done();
+        });
+      });
+    });
+
+    describe('when the request returns something else', function() {
+
+      describe('when the x-akismet-debug-help header is present', function() {
+
+        var client;
+        var scope;
+
+        beforeEach(function() {
+          client = Akismet.client({
+            blog : 'http://example.com',
+            key  : 'testKey6'
+          });
+          scope = nock('http://testKey6.rest.akismet.com')
+              .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+              .post('/1.1/comment-check')
+              .reply(200, 'notAValidValueAtAll', {
+                'Content-Type' : 'text/plain',
+                'X-akismet-debug-help' : 'You did something wrong!'
+              });
+        });
+
+        it('should return the akismet debug error', function(done) {
+          client.checkSpamAsync({
+            user_ip : '123.123.123.123'
+          }).catch(function(err) {
+            expect(err).to.equal('You did something wrong!');
+            scope.done();
+            done();
+          });
+        });
+
+      });
+
+      describe('when the x-akismet-debug-help header is not present', function() {
+
+        var client;
+        var scope;
+
+        beforeEach(function() {
+          client = Akismet.client({
+            blog : 'http://example.com',
+            key  : 'testKey6'
+          });
+          scope = nock('http://testKey6.rest.akismet.com')
+              .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+              .post('/1.1/comment-check')
+              .reply(200, 'notAValidValueAtAll', {
+                'Content-Type' : 'text/plain'
+              });
+        });
+
+        it('should return the response', function(done) {
+          client.checkSpamAsync({
+            user_ip : '123.123.123.123'
+          }).catch(function(err) {
+            expect(err).to.equal('notAValidValueAtAll');
+            scope.done();
+            done();
+          });
+        });
+      });
+
+    });
+
+    describe('when the request fails', function() {
+
+      var client;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey7',
+          host : 'localhost' // will fail!
+        });
+      });
+
+      it('should return the error', function(done) {
+        client.checkSpamAsync({
+          user_ip : '123.123.123.123'
+        }).catch(function(err) {
+          expect(err).to.not.be.null;
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('client#submitSpam()', function() {
+
+    describe('when the request returns a 2XX status code ', function() {
+
+      var client;
+      var scope;
+
       beforeEach(function() {
         client = Akismet.client({
           blog : 'http://example.com',
           key  : 'testKey8'
         });
         scope = nock('http://testKey8.rest.akismet.com')
-        .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-        .post('/1.1/submit-spam')
-        .reply(200, 'Thank you for making the internet a better place', {
-          'Content-Type' : 'text/plain'
-        });
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-spam')
+            .reply(200, 'Thank you for making the internet a better place', {
+              'Content-Type' : 'text/plain'
+            });
       });
- 
+
       it('should return null', function(done) {
         client.submitSpam({
           user_ip : '123.123.123.123'
@@ -468,25 +758,25 @@ describe('Akismet-api', function() {
           done();
         });
       });
- 
+
     });
- 
+
     describe('when the request returns a non 2XX status code', function() {
-    
+
       var client;
       var scope;
-      
+
       beforeEach(function() {
         client = Akismet.client({
           blog : 'http://example.com',
           key  : 'testKey9'
         });
         scope = nock('http://testKey9.rest.akismet.com')
-        .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-        .post('/1.1/submit-spam')
-        .reply(500, 'Oh, whoops.', {
-          'Content-Type' : 'text/plain'
-        });
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-spam')
+            .reply(500, 'Oh, whoops.', {
+              'Content-Type' : 'text/plain'
+            });
       });
 
       it('should return the message', function(done) {
@@ -498,13 +788,13 @@ describe('Akismet-api', function() {
           done();
         });
       });
- 
+
     });
 
     describe('when the request fails', function() {
-    
+
       var client;
-      
+
       beforeEach(function() {
         client = Akismet.client({
           blog : 'http://example.com',
@@ -524,6 +814,90 @@ describe('Akismet-api', function() {
 
     });
 
+  });
+
+  describe('client#submitSpamAsync()', function() {
+
+    describe('when the request returns a 2XX status code ', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey8'
+        });
+        scope = nock('http://testKey8.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-spam')
+            .reply(200, 'Thank you for making the internet a better place', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should resolve', function(done) {
+        client.submitSpamAsync({
+          user_ip : '123.123.123.123'
+        }).then(function(){
+          scope.done();
+          done();
+        })
+      });
+
+    });
+
+    describe('when the request returns a non 2XX status code', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey9'
+        });
+        scope = nock('http://testKey9.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-spam')
+            .reply(500, 'Oh, whoops.', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should return the message', function(done) {
+        client.submitSpamAsync({
+          user_ip : '123.123.123.123'
+        }).catch(function(err) {
+              expect(err).to.equal('Oh, whoops.');
+              scope.done();
+              done();
+         });
+      });
+
+    });
+
+    describe('when the request fails', function() {
+
+      var client;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey10',
+          host : 'localhost' // will fail!
+        });
+      });
+
+      it('should return the error', function(done) {
+        client.submitSpamAsync({
+          user_ip : '123.123.123.123'
+        }).catch(function(err) {
+          expect(err).to.not.be.null;
+          done();
+        });
+      });
+    });
   });
 
   describe('client#submitHam()', function() {
@@ -604,6 +978,92 @@ describe('Akismet-api', function() {
         client.submitHam({
           user_ip : '123.123.123.123'
         }, function(err) {
+          expect(err).to.not.be.null;
+          done();
+        });
+      });
+
+    });
+
+  });
+
+  describe('client#submitHamAsync()', function() {
+
+    describe('when the request returns a 2XX status code ', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey11'
+        });
+        scope = nock('http://testKey11.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-ham')
+            .reply(200, 'Thank you for making the internet a better place', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should resolve', function(done) {
+        client.submitHamAsync({
+          user_ip : '123.123.123.123'
+        }).then(function(){
+          scope.done();
+          done();
+        })
+      });
+
+    });
+
+    describe('when the request returns a non 2XX status code', function() {
+
+      var client;
+      var scope;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey12'
+        });
+        scope = nock('http://testKey12.rest.akismet.com')
+            .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+            .post('/1.1/submit-ham')
+            .reply(500, 'Oh, whoops.', {
+              'Content-Type' : 'text/plain'
+            });
+      });
+
+      it('should return the message', function(done) {
+        client.submitHamAsync({
+          user_ip : '123.123.123.123'
+        }).catch(function(err) {
+          expect(err).to.equal('Oh, whoops.');
+          scope.done();
+          done();
+        });
+      });
+
+    });
+
+    describe('when the request fails', function() {
+
+      var client;
+
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey13',
+          host : 'localhost' // will fail!
+        });
+      });
+
+      it('should return the error', function(done) {
+        client.submitHamAsync({
+          user_ip : '123.123.123.123'
+        }).catch(function(err) {
           expect(err).to.not.be.null;
           done();
         });


### PR DESCRIPTION
I have added functions that return promises with the exact same names but with an "Async" suffix.

The usage can be seen in the unit tests: 
- for success with data e.g.:

    client.checkSpamAsync({
         user_ip : '123.123.123.123'
     }).then(function(spam) {
            expect(spam).to.be.true;
    });

- for error e.g.
    client.checkSpamAsync({
            user_ip : '123.123.123.123'
    }).catch(function(err) {
            expect(err).to.equal('You did something wrong!');
    });
