### PR TITLE
Add promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ var client = akismet.client({
 });
 ```
 
+Promises and Callbacks
+----------------------
+
+All of the function methods below support both promises and callbacks!
+The returned promises use the [Bluebird](https://github.com/petkaantonov/bluebird) promise library.
+The following documentation primarily uses the callback version, but to return a promise simply don't provide a callback.
+Here is an example of the promise version of the `verifyKey()` function:
+
+```javascript
+client.verifyKey()
+.then(function(valid) {
+  if (valid) console.log('Valid key!');
+  else console.log('Invalid key');
+})
+.catch(function(err) {
+  console.log('Check failed: ' + err.message);
+}):
+```
+
 Verifying your Key
 ------------------
 
@@ -44,12 +63,9 @@ It's a good idea to verify your key before use. If your key returns as invalid, 
 
 ```javascript
 client.verifyKey(function(err, valid) {
-  if (valid) {
-    console.log('Valid key!');
-  } else {
-    console.log('Key validation failed...');
-    console.log(err.message);
-  }
+  if (err) console.log('Error:', err.message);
+  if (valid) console.log('Valid key!');
+  else console.log('Invalid key!');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here is an example of the promise version of the `verifyKey()` function:
 client.verifyKey()
 .then(function(valid) {
   if (valid) console.log('Valid key!');
-  else console.log('Invalid key');
+  else console.log('Invalid key!');
 })
 .catch(function(err) {
   console.log('Check failed: ' + err.message);

--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -55,6 +55,7 @@ var Akismet = function(options) {
    * Returns true for spam
    * Return false for ham 
    */
+
   this.checkSpam = function(options, cb) {
     var url = this.endpoint + 'comment-check';
     options = options || {};
@@ -78,8 +79,8 @@ var Akismet = function(options) {
     .then(function(res) {
       if (res.text == 'true') return true;
       if (res.text == 'false') return false;
-      if (res.header['x-akismet-debug-help']) throw new Error(res.header['x-akismet-debug-help']);
       if (res.text == 'invalid') throw new Error('Invalid API key');
+      if (res.header['x-akismet-debug-help']) throw new Error(res.header['x-akismet-debug-help']);
       throw new Error(res.text);
     })
     .asCallback(cb);
@@ -121,6 +122,7 @@ var Akismet = function(options) {
    * Submit the given value as a false-positive
    * Essentially, tell Akismet that they told us this WAS spam, but it WASN'T 
    */
+
   this.submitHam = function(options, cb) {
     var url = this.endpoint + 'submit-ham';
     options = options || {};
@@ -157,6 +159,7 @@ module.exports = {
   /*
    * Shorthand Client constructor function 
    */
+
   client: function(options) {
     return new Akismet(options);
   }

--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -6,15 +6,18 @@
  * See README for more info 
  */
 
-require("setimmediate"); // Shim to support setImmediate in Node 0.8.x
-
+var Promise = require('bluebird');
 var request = require('superagent');
+
+require('setimmediate'); // Shim to support setImmediate in Node 0.8.x
+Promise.promisifyAll(request);
 
 var Akismet = function(options) {
 
   /*
    * Configure our client based on provided options 
    */
+
   options         = options || {};
   this.key        = options.key;
   this.blog       = options.blog;
@@ -27,9 +30,10 @@ var Akismet = function(options) {
   /*
    * Verify that the provided key is accepted by Akismet 
    */
+
   this.verifyKey = function(cb) {
     var url = this.host + '/' + this.version + '/verify-key';
-    request
+    return request
     .post(url)
     .type('form')
     .send({
@@ -37,16 +41,13 @@ var Akismet = function(options) {
       blog : this.blog
     })
     .set('User-Agent', this.userAgent)
-    .end(function(err, res) {
-      if (err) cb(err, null);
-      else if (res.text == 'valid') cb(null, true);
-      else if (res.header['x-akismet-debug-help']) 
-        cb(new Error(res.header['x-akismet-debug-help']), false);
-      else if (res.text == 'invalid')
-        cb(new Error('Invalid API key'), false);
-      else 
-        cb(new Error(res.text), false);
-    });
+    .endAsync()
+    .then(function(res) {
+      if (res.text == 'valid') return true;
+      if (res.text == 'invalid') return false;
+      throw new Error(res.text);
+    })
+    .asCallback(cb);
   };
 
   /*
@@ -57,7 +58,7 @@ var Akismet = function(options) {
   this.checkSpam = function(options, cb) {
     var url = this.endpoint + 'comment-check';
     options = options || {};
-    request
+    return request
     .post(url)
     .type('form')
     .send({
@@ -73,17 +74,15 @@ var Akismet = function(options) {
       referrer             : options.referrer || options.referer || ''
     })
     .set('User-Agent', this.userAgent)
-    .end(function(err, res) {
-      if (err) cb(err, null);
-      else if (res.text == 'true') cb(null, true);
-      else if (res.text == 'false') cb(null, false);
-      else if (res.header['x-akismet-debug-help']) 
-        cb(new Error(res.header['x-akismet-debug-help']), null);
-      else if (res.text == 'invalid')
-        cb(new Error('Invalid API key'), null);
-      else 
-        cb(new Error(res.text), null);
-    });
+    .endAsync()
+    .then(function(res) {
+      if (res.text == 'true') return true;
+      if (res.text == 'false') return false;
+      if (res.header['x-akismet-debug-help']) throw new Error(res.header['x-akismet-debug-help']);
+      if (res.text == 'invalid') throw new Error('Invalid API key');
+      throw new Error(res.text);
+    })
+    .asCallback(cb);
   };
 
   /*
@@ -94,7 +93,7 @@ var Akismet = function(options) {
   this.submitSpam = function(options, cb) {
     var url = this.endpoint + 'submit-spam';
     options = options || {};
-    request
+    return request
     .post(url)
     .type('form')
     .send({
@@ -110,11 +109,12 @@ var Akismet = function(options) {
       referrer             : options.referrer || options.referer || ''
     })
     .set('User-Agent', this.userAgent)
-    .end(function(err, res) { 
-      if (err) cb(err);
-      else if (res.statusType == 2) cb(null);
-      else cb(res.text);
-    });
+    .endAsync()
+    .then(function(res) { 
+      if (res.statusType == 2) return;
+      throw new Error(res.text);
+    })
+    .asCallback(cb);
   };
 
   /*
@@ -124,7 +124,7 @@ var Akismet = function(options) {
   this.submitHam = function(options, cb) {
     var url = this.endpoint + 'submit-ham';
     options = options || {};
-    request
+    return request
     .post(url)
     .type('form')
     .send({
@@ -140,11 +140,12 @@ var Akismet = function(options) {
       referrer             : options.referrer || options.referer || ''
     })
     .set('User-agent', this.userAgent)
-    .end(function(err, res) {
-      if (err) cb(err);
-      else if (res.statusType == 2) cb(null);
-      else cb(res.text);
-    });
+    .endAsync()
+    .then(function(res) {
+      if (res.statusType == 2) return;
+      throw new Error(res.text);
+    })
+    .asCallback(cb);
   };
 
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Nodejs bindings to the Akismet (http://akismet.com) spam detection service",
   "main": "lib/akismet.js",
   "dependencies": {
+    "bluebird": "^3.1.1",
     "setimmediate": "^1.0.2",
     "superagent": "^0.21.0"
   },

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -12,7 +12,7 @@ var expect = chai.expect;
 describe('Akismet-api', function() {
 
   describe('#client()', function() {
-    
+ 
     it('should return an instance of Akismet', function() {
       var client = Akismet.client({
         blog   : 'http://example.com',
@@ -20,7 +20,7 @@ describe('Akismet-api', function() {
       });
       expect(client instanceof Akismet.Client).to.be.true;
     });
-    
+ 
     it('should assign the passed-in variables', function() {
       var client = Akismet.client({
         blog      : 'http://example.com',
@@ -99,79 +99,37 @@ describe('Akismet-api', function() {
 
     describe('when the request returns \'invalid\'', function() {
 
-      describe('when the x-akismet-debug-help header is present', function() {
-
-        var client;
-        var scope;
-        
-        beforeEach(function() {
-          client = Akismet.client({
-            blog : 'http://example.com',
-            key  : 'testKey2',
-            host : 'rest2.akismet.com'
-          });
-          scope = nock('http://rest2.akismet.com')
-          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-          .post('/1.1/verify-key')
-          .reply(200, 'invalid', {
-            'Content-Type' : 'text/plain',
-            'X-akismet-debug-help' : 'Could not find your key'
-          });
-        });
-
-        it('should return false', function(done) {
-          client.verifyKey(function(err, valid) {
-            expect(valid).to.be.false;
-            scope.done();
-            done();
-          });
-        });
-
-        it('should return the akismet debug error', function(done) {
-          client.verifyKey(function(err, valid) {
-            expect(err.message).to.equal('Could not find your key');
-            scope.done();
-            done();
-          });
-        });
+      var client;
+      var scope;
       
+      beforeEach(function() {
+        client = Akismet.client({
+          blog : 'http://example.com',
+          key  : 'testKey2',
+          host : 'rest2.akismet.com'
+        });
+        scope = nock('http://rest2.akismet.com')
+        .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+        .post('/1.1/verify-key')
+        .reply(200, 'invalid', {
+          'Content-Type' : 'text/plain'
+        });
       });
 
-      describe('when the x-akismet-debug-help header is not present', function() {
-
-        var client;
-        var scope;
-        
-        beforeEach(function() {
-          client = Akismet.client({
-            blog : 'http://example.com',
-            key  : 'testKey2',
-            host : 'rest2.akismet.com'
-          });
-          scope = nock('http://rest2.akismet.com')
-          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-          .post('/1.1/verify-key')
-          .reply(200, 'invalid', {
-            'Content-Type' : 'text/plain'
-          });
+      it('should return false', function(done) {
+        client.verifyKey(function(err, valid) {
+          expect(valid).to.be.false;
+          scope.done();
+          done();
         });
+      });
 
-        it('should return false', function(done) {
-          client.verifyKey(function(err, valid) {
-            expect(valid).to.be.false;
-            scope.done();
-            done();
-          });
+      it('should return \'Invalid API key\'', function(done) {
+        client.verifyKey(function(err, valid) {
+          expect(err.message).to.equal('Invalid API key');
+          scope.done();
+          done();
         });
-
-        it('should return \'Invalid API key\'', function(done) {
-          client.verifyKey(function(err, valid) {
-            expect(err.message).to.equal('Invalid API key');
-            scope.done();
-            done();
-          });
-        });
-      
       });
 
     });

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -153,9 +153,9 @@ describe('Akismet-api', function() {
         });
       });
 
-      it('should return false', function(done) {
+      it('should return falsey', function(done) {
         client.verifyKey(function(err, valid) {
-          expect(valid).to.be.false;
+          expect(valid).to.be.falsey;
           scope.done();
           done();
         });
@@ -183,10 +183,10 @@ describe('Akismet-api', function() {
         });
       });
 
-      it('should return null', function(done) {
+      it('should return falsey', function(done) {
         client.verifyKey(function(err, valid) {
           expect(err).to.not.be.false;
-          expect(valid).to.be.null;
+          expect(valid).to.be.falsey;
           done();
         });
       });
@@ -310,11 +310,11 @@ describe('Akismet-api', function() {
           });
         });
 
-        it('should return null', function(done) {
+        it('should return falsey', function(done) {
           client.checkSpam({
             user_ip : '123.123.123.123'
           }, function(err, spam) {
-            expect(spam).to.be.null;
+            expect(spam).to.be.falsey;
             scope.done();
             done();
           });
@@ -350,11 +350,11 @@ describe('Akismet-api', function() {
           });
         });
 
-        it('should return null', function(done) {
+        it('should return falsey', function(done) {
           client.checkSpam({
             user_ip : '123.123.123.123'
           }, function(err, spam) {
-            expect(spam).to.be.null;
+            expect(spam).to.be.falsey;
             scope.done();
             done();
           });
@@ -386,11 +386,11 @@ describe('Akismet-api', function() {
         });
       });
 
-      it('should return null', function(done) {
+      it('should return falsey', function(done) {
         client.checkSpam({
           user_ip : '123.123.123.123'
         }, function(err, spam) {
-          expect(spam).to.be.null;
+          expect(spam).to.be.falsey;
           done();
         });
       });

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -3,6 +3,7 @@
  * Describes tests for the akismet-api module */
 
 var Akismet = require('../lib/akismet');
+var Promise = require('bluebird');
 var chai    = require('chai');
 var nock    = require('nock');
 
@@ -53,6 +54,11 @@ describe('Akismet-api', function() {
   });
 
   describe('client#verifyKey()', function() {
+
+    it('should support promises', function() {
+      var client = Akismet.client();
+      expect(client.verifyKey()).to.be.an.instanceof(Promise);
+    });
   
     describe('when the request returns \'valid\'', function() {
 
@@ -239,6 +245,11 @@ describe('Akismet-api', function() {
   });
 
   describe('client#checkSpam()', function() {
+
+    it('should support promises', function() {
+      var client = Akismet.client();
+      expect(client.verifyKey()).to.be.an.instanceof(Promise);
+    });
     
     describe('when the request returns \'true\'', function() {
     
@@ -440,6 +451,11 @@ describe('Akismet-api', function() {
   });
 
   describe('client#submitSpam()', function() {
+
+    it('should support promises', function() {
+      var client = Akismet.client();
+      expect(client.verifyKey()).to.be.an.instanceof(Promise);
+    });
  
     describe('when the request returns a 2XX status code ', function() {
     
@@ -527,6 +543,11 @@ describe('Akismet-api', function() {
   });
 
   describe('client#submitHam()', function() {
+
+    it('should support promises', function() {
+      var client = Akismet.client();
+      expect(client.verifyKey()).to.be.an.instanceof(Promise);
+    });
     
     describe('when the request returns a 2XX status code ', function() {
     

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -124,9 +124,9 @@ describe('Akismet-api', function() {
         });
       });
 
-      it('should return \'Invalid API key\'', function(done) {
+      it('should not return an error', function(done) {
         client.verifyKey(function(err, valid) {
-          expect(err.message).to.equal('Invalid API key');
+          expect(err).to.be.null;
           scope.done();
           done();
         });

--- a/test/akismet.spec.js
+++ b/test/akismet.spec.js
@@ -467,7 +467,7 @@ describe('Akismet-api', function() {
         client.submitSpam({
           user_ip : '123.123.123.123'
         }, function(err) {
-          expect(err).to.equal('Oh, whoops.');
+          expect(err.message).to.equal('Oh, whoops.');
           scope.done();
           done();
         });
@@ -559,7 +559,7 @@ describe('Akismet-api', function() {
         client.submitHam({
           user_ip : '123.123.123.123'
         }, function(err) {
-          expect(err).to.equal('Oh, whoops.');
+          expect(err.message).to.equal('Oh, whoops.');
           scope.done();
           done();
         });


### PR DESCRIPTION
This is based on the work done in PR #14 that adds promises. This alternative method allows users of both promises and callbacks to use the same function names, and doesn't increase the codebase size.

This makes some (very minor) breaking changes to the way error objects are returned to callbacks.

@andapopovici, can you take a look at this? I based this on your work, I think this is slightly more readable but I want to ensure it still meets all your original implementation goals.