### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Akismet-api
 [![Build Status](https://img.shields.io/travis/chrisfosterelli/akismet-api.svg?maxAge=3600&style=flat-square)](https://travis-ci.org/chrisfosterelli/akismet-api)
 [![Dependency Status](https://img.shields.io/david/chrisfosterelli/akismet-api.svg?maxAge=3600&style=flat-square)](https://david-dm.org/chrisfosterelli/akismet-api)
 [![Download Count](https://img.shields.io/npm/dm/akismet-api.svg?maxAge=3600&style=flat-square)](https://www.npmjs.com/package/akismet-api)
-[![License](https://img.shields.io/npm/l/akismet-api.svg?maxAge=3600&style=flat-square)](LICENSE.md)
+[![License](https://img.shields.io/npm/l/akismet-api.svg?maxAge=3600&style=flat-square)](LICENSE.txt)
 
 Full Nodejs bindings to the Akismet (http://akismet.com) spam detection service.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Akismet-api
 ===========
 
-[![Build Status](https://travis-ci.org/chrisfosterelli/akismet-api.svg?branch=master)](https://travis-ci.org/chrisfosterelli/akismet-api)
-[![Dependency Status](https://david-dm.org/chrisfosterelli/akismet-api.png)](https://david-dm.org/chrisfosterelli/akismet-api)
+[![Build Status](https://img.shields.io/travis/chrisfosterelli/akismet-api.svg?maxAge=3600&style=flat-square)](https://travis-ci.org/chrisfosterelli/akismet-api)
+[![Dependency Status](https://img.shields.io/david/chrisfosterelli/akismet-api.svg?maxAge=3600&style=flat-square)](https://david-dm.org/chrisfosterelli/akismet-api)
+[![Download Count](https://img.shields.io/npm/dm/akismet-api.svg?maxAge=3600&style=flat-square)](https://www.npmjs.com/package/akismet-api)
+[![License](https://img.shields.io/npm/l/akismet-api.svg?maxAge=3600&style=flat-square)](LICENSE.md)
 
 Full Nodejs bindings to the Akismet (http://akismet.com) spam detection service.
 


### PR DESCRIPTION
We now use shields.io (more visually consistent) and also add a download count and license pill.

Resolves #10 