### PR TITLE
Bump superagent version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bluebird": "^3.1.1",
     "setimmediate": "^1.0.2",
-    "superagent": "^1.8.3"
+    "superagent": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
They made a breaking change regarding how promises work, but it appears that all the tests pass so I don't think it matters since we use bluebird to wrap it.