### PR TITLE
Add is_test option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ client.checkSpam({
   comment_author_email : 'john.smith@gmail.com',
   comment_author_url : 'http://johnsblog.com',
   comment_content : 'Very nice blog! Check out mine!'
+  is_test : true // Default value is false
 }, function(err, spam) {
   if (err) console.log ('Error!');
   if (spam) {

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ client.checkSpam({
   comment_author : 'John Smith',
   comment_author_email : 'john.smith@gmail.com',
   comment_author_url : 'http://johnsblog.com',
-  comment_content : 'Very nice blog! Check out mine!'
+  comment_content : 'Very nice blog! Check out mine!',
   is_test : true // Default value is false
 }, function(err, spam) {
   if (err) console.log ('Error!');

--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -73,7 +73,8 @@ var Akismet = function(options) {
       comment_content      : options.comment_content || '',
       comment_author_url   : options.comment_author_url || '',
       comment_author_email : options.comment_author_email || '',
-      referrer             : options.referrer || options.referer || ''
+      referrer             : options.referrer || options.referer || '',
+      is_test              : options.is_test === true
     })
     .set('User-Agent', this.userAgent)
     .endAsync()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akismet-api",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "description": "Nodejs bindings to the Akismet (http://akismet.com) spam detection service",
   "main": "lib/akismet.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akismet-api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Nodejs bindings to the Akismet (http://akismet.com) spam detection service",
   "main": "lib/akismet.js",
   "dependencies": {


### PR DESCRIPTION
This pull request adds the `is_test` option when checking for spam.

Library and readme have been updated. The gitignore file has also been updated because I use webstorm as my IDE and it adds a load of artefacts in a .idea folder that you really don't want added to source control