### PR TITLE
Add dates to submission options

### DIFF
--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -1,9 +1,9 @@
 
-/* 
+/*
  * akismet.js
- * Provide Nodejs API bindings to the Akismet web service 
- * "Ham" refers to anything not spam 
- * See README for more info 
+ * Provide Nodejs API bindings to the Akismet web service
+ * "Ham" refers to anything not spam
+ * See README for more info
  */
 
 var Promise = require('bluebird');
@@ -15,7 +15,7 @@ Promise.promisifyAll(request);
 var Akismet = function(options) {
 
   /*
-  /* Configure our client based on provided options 
+  /* Configure our client based on provided options
    */
 
   options        = options || {};
@@ -29,7 +29,7 @@ var Akismet = function(options) {
   this.userAgent = options.userAgent || 'Node.js/' + process.version + ' | Akismet-api/' + pjson.version;
 
   /*
-   * Verify that the provided key is accepted by Akismet 
+   * Verify that the provided key is accepted by Akismet
    */
 
   this.verifyKey = function(cb) {
@@ -52,9 +52,9 @@ var Akismet = function(options) {
   };
 
   /*
-   * Check if the given data is spam 
+   * Check if the given data is spam
    * Returns true for spam
-   * Return false for ham 
+   * Return false for ham
    */
 
   this.checkSpam = function(options, cb) {
@@ -92,7 +92,7 @@ var Akismet = function(options) {
 
   /*
    * Submit the given value as a false-negative
-   * Essentially, tell Akismet that they told us this WASN'T spam, but it WAS 
+   * Essentially, tell Akismet that they told us this WASN'T spam, but it WAS
    */
 
   this.submitSpam = function(options, cb) {
@@ -123,7 +123,7 @@ var Akismet = function(options) {
 
   /*
    * Submit the given value as a false-positive
-   * Essentially, tell Akismet that they told us this WAS spam, but it WASN'T 
+   * Essentially, tell Akismet that they told us this WAS spam, but it WASN'T
    */
 
   this.submitHam = function(options, cb) {
@@ -159,7 +159,7 @@ module.exports = {
   Client : Akismet,
 
   /*
-   * Shorthand Client constructor function 
+   * Shorthand Client constructor function
    */
 
   client: function(options) {

--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -64,17 +64,19 @@ var Akismet = function(options) {
     .post(url)
     .type('form')
     .send({
-      blog                 : this.blog,
-      user_ip              : options.user_ip || '',
-      permalink            : options.permalink || '',
-      user_agent           : options.user_agent || '',
-      comment_type         : options.comment_type || '',
-      comment_author       : options.comment_author || '',
-      comment_content      : options.comment_content || '',
-      comment_author_url   : options.comment_author_url || '',
-      comment_author_email : options.comment_author_email || '',
-      referrer             : options.referrer || options.referer || '',
-      is_test              : options.is_test === true
+      blog                      : this.blog,
+      user_ip                   : options.user_ip || '',
+      permalink                 : options.permalink || '',
+      user_agent                : options.user_agent || '',
+      comment_type              : options.comment_type || '',
+      comment_author            : options.comment_author || '',
+      comment_content           : options.comment_content || '',
+      comment_author_url        : options.comment_author_url || '',
+      comment_author_email      : options.comment_author_email || '',
+      comment_date_gmt          : options.comment_date_gmt || '',
+      comment_post_modified_gmt : options.comment_post_modified_gmt  || '',
+      referrer                  : options.referrer || options.referer || '',
+      is_test                   : options.is_test === true
     })
     .set('User-Agent', this.userAgent)
     .endAsync()
@@ -100,17 +102,19 @@ var Akismet = function(options) {
     .post(url)
     .type('form')
     .send({
-      blog                 : this.blog,
-      user_ip              : options.user_ip || '',
-      permalink            : options.permalink || '',
-      user_agent           : options.user_agent || '',
-      comment_type         : options.comment_type || '',
-      comment_author       : options.comment_author || '',
-      comment_content      : options.comment_content || '',
-      comment_author_url   : options.comment_author_url || '',
-      comment_author_email : options.comment_author_email || '',
-      referrer             : options.referrer || options.referer || '',
-      is_test              : options.is_test === true
+      blog                      : this.blog,
+      user_ip                   : options.user_ip || '',
+      permalink                 : options.permalink || '',
+      user_agent                : options.user_agent || '',
+      comment_type              : options.comment_type || '',
+      comment_author            : options.comment_author || '',
+      comment_content           : options.comment_content || '',
+      comment_author_url        : options.comment_author_url || '',
+      comment_author_email      : options.comment_author_email || '',
+      comment_date_gmt          : options.comment_date_gmt || '',
+      comment_post_modified_gmt : options.comment_post_modified_gmt  || '',
+      referrer                  : options.referrer || options.referer || '',
+      is_test                   : options.is_test === true
     })
     .set('User-Agent', this.userAgent)
     .endAsync()
@@ -129,17 +133,19 @@ var Akismet = function(options) {
     .post(url)
     .type('form')
     .send({
-      blog                 : this.blog,
-      user_ip              : options.user_ip || '',
-      permalink            : options.permalink || '',
-      user_agent           : options.user_agent || '',
-      comment_type         : options.comment_type || '',
-      comment_author       : options.comment_author || '',
-      comment_content      : options.comment_content || '',
-      comment_author_url   : options.comment_author_url || '',
-      comment_author_email : options.comment_author_email || '',
-      referrer             : options.referrer || options.referer || '',
-      is_test              : options.is_test === true
+      blog                      : this.blog,
+      user_ip                   : options.user_ip || '',
+      permalink                 : options.permalink || '',
+      user_agent                : options.user_agent || '',
+      comment_type              : options.comment_type || '',
+      comment_author            : options.comment_author || '',
+      comment_content           : options.comment_content || '',
+      comment_author_url        : options.comment_author_url || '',
+      comment_author_email      : options.comment_author_email || '',
+      comment_date_gmt          : options.comment_date_gmt || '',
+      comment_post_modified_gmt : options.comment_post_modified_gmt  || '',
+      referrer                  : options.referrer || options.referer || '',
+      is_test                   : options.is_test === true
     })
     .set('User-agent', this.userAgent)
     .endAsync()


### PR DESCRIPTION
This adds `comment_date_gmt` and `comment_post_modified_gmt` to every possible API call, as documented in https://akismet.com/development/api/.

Like other options, this does no verification of passed in values, but all dates sent should be ISO 8601.

This also strips trailing whitespace from a few lines.