### PR TITLE
support for user_role parameter on checkSpam() API

### DIFF
--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -76,6 +76,7 @@ var Akismet = function(options) {
       comment_date_gmt          : options.comment_date_gmt || '',
       comment_post_modified_gmt : options.comment_post_modified_gmt  || '',
       referrer                  : options.referrer || options.referer || '',
+      user_role                 : options.user_role || '',
       is_test                   : options.is_test === true
     })
     .set('User-Agent', this.userAgent)


### PR DESCRIPTION
user_role is used in the Akismet API in test mode to trigger a guaranteed 'ham' response.