### PR TITLE
Add honeypot field support

### DIFF
--- a/docs/comments.md
+++ b/docs/comments.md
@@ -23,3 +23,29 @@ Provide as many of these as you can as it really helps with accuracy.
 | `type` | `comment_type` | The type of comment (e.g. 'comment', 'reply', 'forum-post', 'blog-post') |
 | `role` | `user_role` | The commentor's 'role'. If set to 'administrator', it will never be marked spam |
 | `isTest` | `is_test` | Set this to `true` for your automated tests |
+
+Honeypot field
+--------------
+
+Akismet supports a ["honeypot" field]. Honeypot fields are visually hidden
+inputs which trick bot users into completing a field that human users can't
+detect. If your form is submitted with a value in the honeypot field it is a
+very strong signal for spam, because only a bot would detect and complete the
+field. For convenience, Akismet-api provides a single field for honeypot values:
+
+```javascript
+comment['honeypot'] = myForm['myHoneypotField']
+```
+
+Like other comment fields, you can also use the official snake case API
+attributes (both are equivalent):
+
+```javascript
+comment['honeypot_field_name'] = 'myHoneypotField'
+comment['myHoneypotField'] = myForm['myHoneypotField']
+```
+
+Make sure that, on the user interface side, your honeypot field is hidden via
+CSS or Javascript.
+
+["honeypot" fields]: https://en.wikipedia.org/wiki/Honeypot_(computing)

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -22,6 +22,7 @@ Provide as many of these as you can as it really helps with accuracy.
 | `recheck` | `recheck_reason` | If checking a previously checked comment, you can provide a reason why (e.g. 'edit') |
 | `type` | `comment_type` | The type of comment (e.g. 'comment', 'reply', 'forum-post', 'blog-post') |
 | `role` | `user_role` | The commentor's 'role'. If set to 'administrator', it will never be marked spam |
+| `honeypot` | `honeypot_field_name` | See section below for detailed description |
 | `isTest` | `is_test` | Set this to `true` for your automated tests |
 
 Honeypot field

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -27,7 +27,7 @@ Provide as many of these as you can as it really helps with accuracy.
 Honeypot field
 --------------
 
-Akismet supports a ["honeypot" field]. Honeypot fields are visually hidden
+Akismet supports a ["honeypot" field][0]. Honeypot fields are visually hidden
 inputs which trick bot users into completing a field that human users can't
 detect. If your form is submitted with a value in the honeypot field it is a
 very strong signal for spam, because only a bot would detect and complete the
@@ -48,4 +48,4 @@ comment['myHoneypotField'] = myForm['myHoneypotField']
 Make sure that, on the user interface side, your honeypot field is hidden via
 CSS or Javascript.
 
-["honeypot" fields]: https://en.wikipedia.org/wiki/Honeypot_(computing)
+[0]: https://en.wikipedia.org/wiki/Honeypot_(computing)

--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -39,6 +39,24 @@ function mapAliases(input, aliases = commentAliases) {
   return output
 }
 
+function getHoneypotFields(input) {
+  const honeypotKey = 'honeypot_field_name'
+  const honeypotFieldName = 'akismet_api_honeypot_field'
+  if (input[honeypotKey]) {
+    return {
+      [honeypotKey]: input[honeypotKey],
+      [input[honeypotKey]]: input[input[honeypotKey]]
+    }
+  } else if (input.honeypot) {
+    return {
+      [honeypotKey]: honeypotFieldName,
+      [honeypotFieldName]: input.honeypot
+    }
+  } else {
+    return {}
+  }
+}
+
 class AkismetClient {
   // Configure our client based on provided options
   constructor(options = {}) {
@@ -79,7 +97,11 @@ class AkismetClient {
   // Check if the given data is spam
   checkSpam(comment = {}, cb) {
     const url = `${this.endpoint}comment-check`
-    comment = { ...mapAliases(comment), ...this.requestOpts }
+    comment = {
+      ...mapAliases(comment),
+      ...getHoneypotFields(comment),
+      ...this.requestOpts
+    }
     return request
       .post(url)
       .type('form')
@@ -100,7 +122,11 @@ class AkismetClient {
   // Submit the given value as a false-negative
   submitSpam(comment = {}, cb) {
     const url = `${this.endpoint}submit-spam`
-    comment = { ...mapAliases(comment), ...this.requestOpts }
+    comment = {
+      ...mapAliases(comment),
+      ...getHoneypotFields(comment),
+      ...this.requestOpts
+    }
     return request
       .post(url)
       .type('form')
@@ -113,7 +139,11 @@ class AkismetClient {
   // Submit the given value as a false-positive
   submitHam(comment = {}, cb) {
     const url = `${this.endpoint}submit-ham`
-    comment = { ...mapAliases(comment), ...this.requestOpts }
+    comment = {
+      ...mapAliases(comment),
+      ...getHoneypotFields(comment),
+      ...this.requestOpts
+    }
     return request
       .post(url)
       .type('form')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "akismet-api",
       "version": "5.3.0",
       "license": "MIT",
       "dependencies": {

--- a/test/comments.spec.js
+++ b/test/comments.spec.js
@@ -29,6 +29,8 @@ describe('comment structure', () => {
           '&comment_post_modified_gmt=2019-12-22T13%3A05%3A04Z' +
           '&comment_author_url=https%3A%2F%2Fauthorsite.com' +
           '&user_role=user' +
+          '&honeypot_field_name=my_honeypot_field' +
+          '&my_honeypot_field=I%20fell%20for%20the%20honeypot%21' +
           '&blog=https%3A%2F%2Fexample.com' +
           '&blog_lang=en%2C%20fr_ca' +
           '&blog_charset=UTF-8'
@@ -49,6 +51,8 @@ describe('comment structure', () => {
       permalink: 'https://example.com/posts/123215',
       comment_post_modified_gmt: '2019-12-22T13:05:04Z',
       comment_author_url: 'https://authorsite.com',
+      honeypot_field_name: 'my_honeypot_field',
+      my_honeypot_field: 'I fell for the honeypot!',
       user_role: 'user'
     })
     expect(isSpam).to.be.true
@@ -79,6 +83,8 @@ describe('comment structure', () => {
           '&comment_post_modified_gmt=2019-12-22T13%3A05%3A04Z' +
           '&comment_author_url=https%3A%2F%2Fauthorsite.com' +
           '&user_role=user' +
+          '&honeypot_field_name=akismet_api_honeypot_field' +
+          '&akismet_api_honeypot_field=I%20fell%20for%20the%20honeypot%21' +
           '&blog=https%3A%2F%2Fexample.com' +
           '&blog_lang=en%2C%20fr_ca' +
           '&blog_charset=UTF-8'
@@ -99,6 +105,7 @@ describe('comment structure', () => {
       permalink: 'https://example.com/posts/123215',
       permalinkDate: '2019-12-22T13:05:04Z',
       url: 'https://authorsite.com',
+      honeypot: 'I fell for the honeypot!',
       role: 'user'
     })
     expect(isSpam).to.be.true


### PR DESCRIPTION
This adds support for `honeypot_field_name`. I added a convenience method just called `honeypot` that will set both the honeypot field name and the value in the comment. Users can still manually set both if they prefer to do so.

Resolves #204 