### PR TITLE
Support recheck_reason field

### DIFF
--- a/lib/akismet.js
+++ b/lib/akismet.js
@@ -24,7 +24,8 @@ const commentAliases = [
   ['permalink'],
   ['comment_post_modified_gmt', 'permalinkDate'],
   ['comment_author_url', 'url'],
-  ['user_role', 'role']
+  ['user_role', 'role'],
+  ['recheck_reason', 'recheckReason']
 ]
 
 function mapAliases(input, aliases = commentAliases) {


### PR DESCRIPTION
While the documentation says the `recheck_reason` field from the Akismet API is supported, that field was missed from the `commentAliases` array and would therefore never get passed to the server. Add it in to fix.